### PR TITLE
Correct typo 'linx264' to 'libx264'

### DIFF
--- a/airplay/hls.js
+++ b/airplay/hls.js
@@ -216,7 +216,7 @@ HLSServer.prototype.command4FFMpeg = function ( tsIndex, tsOutput ) {
     }
     else {
         opt = opt.concat([
-            '-c:v', 'linx264',
+            '-c:v', 'libx264',
             '-c:a', 'aac',
             // '-g', 100,
             // '-vcodec', 'copy',


### PR DESCRIPTION
I noticed while browsing the code the typo of 'linx264'. This would cause ffmpeg if that code branch were to be followed.
